### PR TITLE
Add json build and implement some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /delete-me/
 /chunk/
 /dist/
+/json/
 /tmp/
 /data/
 /venv/
+
+./test-log

--- a/README.md
+++ b/README.md
@@ -33,4 +33,28 @@ e.g.
 
 ### Building page extracts in dist
 
+Page transcripts and json can be built locally using:
+
     ant -noclasspath -buildfile ./bin/build.xml
+    
+To only build transcripts use:
+
+    ant -noclasspath -buildfile ./bin/build.xml "transcripts"
+
+To only build json use:
+
+    ant -noclasspath -buildfile ./bin/build.xml "json"
+    
+### Tests
+
+To test that all links to transcripts resolve to an existing html page transcription and that all html page transcriptions are pointed to by links in the json use:
+
+    ant -noclasspath -buildfile bin/test.xml
+    
+This command will initiate a full build of both the transcripts and json. If you have already built the transcripts and json and wish to run the tests, use:
+
+    ant -noclasspath -buildfile bin/build.xml "json"
+    
+The results of the test are written to ./test.log
+    
+**NB:** The test will currently crash in the presence of a syntactically invalid json file. This will be rectified shortly.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,18 @@ To only build json use:
     
 ### Tests
 
-To test that all links to transcripts resolve to an existing html page transcription and that all html page transcriptions are pointed to by links in the json use:
+The test suite checks that:
+
+- each JSON file is syntactically valid
+- links to transcripts within the JSON resolve to an existing html file 
+- each html file is pointed to by links within the JSON
+
+Run the tests locally using:
 
     ant -noclasspath -buildfile bin/test.xml
     
-This command will initiate a full build of both the transcripts and json. If you have already built the transcripts and json and wish to run the tests, use:
+This command initiates a full build of the transcripts and json before running the tests. If you have already built the transcripts and json and wish only to run the tests, use:
 
-    ant -noclasspath -buildfile bin/build.xml "json"
+    ant -noclasspath -buildfile bin/build.xml "tests-only"
     
 The results of the test are written to ./test.log
-    
-**NB:** The test will currently crash in the presence of a syntactically invalid json file. This will be rectified shortly.

--- a/bin/build.xml
+++ b/bin/build.xml
@@ -120,6 +120,8 @@
                         value="true"/>
                 </factory>
             </xslt>
+            
+            <delete dir="${xtf.dir}" failonerror="no" />
         </target>
 
         <target name="all" depends="transcripts,json" />

--- a/bin/build.xml
+++ b/bin/build.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <project name="TranformXml" default="TransformAll">
+    <project name="TranformXml" default="transcripts">
+        <dirname property="buildfile.dir" file="${ant.file}"/>
+
+        <property name="data.dir"  value="../data"/><!-- Souce of the original data files -->
+
         <taskdef resource="net/sf/antcontrib/antlib.xml"/>
-        <target name="TransformFile">
-            <dirname property="buildfile.dir" file="${ant.file}"/>
+        
+        <target name="transcripts">
+            <echo message="Generating page transcriptions"/>
+
             <property name="tmp.dir"  value="../tmp"/><!-- Target directory for the TEI XML page extract files -->
-            <property name="dist.dir"  value="../dist"/><!-- Target directory for the final html rendered pages -->
             <property name="chunk.dir"  value="../chunk"/><!-- Chunk directory: target of the chunking process; source of data for the pagify process -->
-            <property name="data.dir"  value="../data"/><!-- Souce of the original data files -->
             <property name="junk.dir"  value="../delete-me"/><!-- Destination directory for empty junk files created by ant's xslt task when running pagify.xsl -->
+            <property name="dist.dir"  value="../dist"/><!-- Target directory for the final html rendered pages -->
             
             <delete dir="${chunk.dir}" />
             <delete dir="${dist.dir}" />
@@ -79,10 +84,43 @@
                 </fileset>
             </copy>
 
-            <delete dir="${chunk.dir}" />
-            <delete dir="${tmp.dir}" />
+            <delete dir="${chunk.dir}" failonerror="no" />
+            <delete dir="${tmp.dir}" failonerror="no" />
             
         </target>
+        
+        <target name="json">
+            <echo message="Generating json files"/>
 
-        <target name="TransformAll" depends="TransformFile" />
+            <property name="xtf.dir"  value="../tmp/xtf"/><!-- target of the xtf indexing results. Source for json xslt -->
+            <property name="json.dir"  value="../json"/><!-- Destination dir for json xslt -->
+            
+            <delete dir="${xtf.dir}" />
+            <delete dir="${json.dir}"/>
+            
+            <mkdir dir="${xtf.dir}"/>
+            <mkdir dir="${json.dir}"/>
+            
+            <fileset id="original_xml" dir="${data.dir}" includes="**/*.xml" />
+            
+            <xslt destdir="${xtf.dir}" style="../xslt/msTeiPreFilter.xsl" force="true" useimplicitfileset="false" extension=".xml"  classpath="saxon/saxon-he-10.2.jar" reloadstylesheet="true">
+                <fileset refid="original_xml"/>
+                <factory name="net.sf.saxon.TransformerFactoryImpl">
+                    <attribute name="http://saxon.sf.net/feature/xinclude-aware"
+                        value="true"/>
+                </factory>
+            </xslt>
+            
+            <fileset id="indexed_files" dir="${xtf.dir}" includes="**/*.xml" />
+            
+            <xslt destdir="${json.dir}" style="../xslt/jsonDocFormatter.xsl" force="true" useimplicitfileset="false" extension=".json"  classpath="saxon/saxon-he-10.2.jar" reloadstylesheet="true">
+                <fileset refid="indexed_files"/>
+                <factory name="net.sf.saxon.TransformerFactoryImpl">
+                    <attribute name="http://saxon.sf.net/feature/xinclude-aware"
+                        value="true"/>
+                </factory>
+            </xslt>
+        </target>
+
+        <target name="all" depends="transcripts,json" />
     </project>

--- a/bin/test-xslt/dump-html.xsl
+++ b/bin/test-xslt/dump-html.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" xmlns:local="local" xmlns:saxon="http://saxon.sf.net/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="#all">
+    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+    
+    <xsl:template match="/">
+        <list>
+            <xsl:for-each select="uri-collection('../../dist/tei/?select=*.html;recurse=yes')">
+                <item>
+                    <xsl:sequence select="replace(.,'^.*/dist/tei/','')"/>
+                </item>
+            </xsl:for-each>
+        </list>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/bin/test-xslt/dump-json.xsl
+++ b/bin/test-xslt/dump-json.xsl
@@ -2,17 +2,28 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" xmlns:local="local" xmlns:saxon="http://saxon.sf.net/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="#all">
     <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
     
+    <xsl:variable name="current_dir" select="concat(string-join(tokenize(document-uri(root(/)),'/')[position() lt last()],'/'),'/')" />
+    <xsl:variable name="json_dir" select="'../../json/tei/'"/>
+    
     <xsl:template match="/">
-        
         <list>
-            <xsl:for-each select="uri-collection('../../json/tei/?select=*.json;recurse=yes')!unparsed-text(.)" saxon:threads="9">
-                <xsl:for-each select="local:convert-json-to-xml(.)//*:string[@key = ('transcriptionDiplomaticURL','translationURL')]">
-                    <xsl:variable name="item" select="local:get-item-uri(.)"/>
-                    <xsl:if test="$item[normalize-space(.)]">
-                        <item n="{normalize-space(.)}">
-                            <xsl:sequence select="$item"/>
-                        </item>
-                    </xsl:if>
+            <xsl:for-each select="uri-collection('../../json/tei/?select=*.json;recurse=yes')" saxon:threads="9">
+                <xsl:for-each select="local:convert-json-to-xml(.)//*:string[@key = ('transcriptionDiplomaticURL','translationURL') or @type='invalid']">
+                    <xsl:choose>
+                        <xsl:when test="@key">
+                            <xsl:variable name="item" select="local:get-item-uri(.)"/>
+                            <xsl:if test="$item[normalize-space(.)]">
+                                <item n="{normalize-space(.)}">
+                                    <xsl:sequence select="$item"/>
+                                </item>
+                            </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <item type="invalid">
+                                <xsl:value-of select="normalize-space(.)"/>
+                            </item>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:for-each>
             </xsl:for-each>
         </list>
@@ -21,9 +32,19 @@
     
     
     <xsl:function name="local:convert-json-to-xml" as="item()*">
-        <xsl:param name="text" />
+        <xsl:param name="file" />
         
-        <xsl:copy-of select="json-to-xml(replace($text, '^[^\{]+', ''))" />
+        <xsl:try select="json-to-xml(replace(unparsed-text($file), '^[^\{]+', ''))" >
+            <xsl:catch>
+                <xsl:message>CRITICAL: <xsl:value-of select="$file"/> is invalid JSON</xsl:message>
+                <xsl:variable name="full_path_to_json" select="resolve-uri($json_dir, $current_dir)"/>
+                <error>
+                    <string type="invalid">
+                        <xsl:value-of select="replace(normalize-space($file), $full_path_to_json, '')"/>
+                    </string>
+                </error>
+            </xsl:catch>
+        </xsl:try>
         
     </xsl:function>
     

--- a/bin/test-xslt/dump-json.xsl
+++ b/bin/test-xslt/dump-json.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" xmlns:local="local" xmlns:saxon="http://saxon.sf.net/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="#all">
+    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+    
+    <xsl:template match="/">
+        
+        <list>
+            <xsl:for-each select="uri-collection('../../json/tei/?select=*.json;recurse=yes')!unparsed-text(.)" saxon:threads="9">
+                <xsl:for-each select="local:convert-json-to-xml(.)//*:string[@key = ('transcriptionDiplomaticURL','translationURL')]">
+                    <xsl:variable name="item" select="local:get-item-uri(.)"/>
+                    <xsl:if test="$item[normalize-space(.)]">
+                        <item n="{normalize-space(.)}">
+                            <xsl:sequence select="$item"/>
+                        </item>
+                    </xsl:if>
+                </xsl:for-each>
+            </xsl:for-each>
+        </list>
+        
+    </xsl:template>
+    
+    
+    <xsl:function name="local:convert-json-to-xml" as="item()*">
+        <xsl:param name="text" />
+        
+        <xsl:copy-of select="json-to-xml(replace($text, '^[^\{]+', ''))" />
+        
+    </xsl:function>
+    
+    <xsl:function name="local:get-item-uri" as="xs:string*">
+        <xsl:param name="string"/>
+        
+        <xsl:if test="matches($string, '^(/v1/transcription/tei/diplomatic/internal/|/v1/translation/tei/[^/]+/)')">
+            <xsl:variable name="type" as="xs:string*">
+                <xsl:choose>
+                    <xsl:when test="matches($string,'/v1/translation/tei/[^/]+/')">
+                        <xsl:value-of select="'translation'"/>
+                    </xsl:when>
+                    <xsl:otherwise/>
+                </xsl:choose>
+            </xsl:variable>
+            
+            <xsl:variable name="classmark" select="tokenize(replace($string,'^(/v1/transcription/tei/diplomatic/internal/|/v1/translation/tei/[^/]+/)', ''),'/')[1]"/>
+            <xsl:variable name="image_tokens" select="tokenize($string,'/')[position() gt index-of(tokenize($string,'/'), $classmark)]"/>
+            <xsl:sequence select="concat(string-join(($classmark,string-join(($classmark, $image_tokens, $type)[normalize-space(.)],'-'))[normalize-space(.)],'/'),'.html')"/>
+        </xsl:if>
+    </xsl:function>
+</xsl:stylesheet>

--- a/bin/test-xslt/main.xsl
+++ b/bin/test-xslt/main.xsl
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" xmlns:local="local" xmlns:saxon="http://saxon.sf.net/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="#all">
+    <xsl:output method="text" encoding="UTF-8"/>
+    
+    <xsl:key name="item" match="//tei:item" use="normalize-space(.)"/>
+    
+    <xsl:template match="/">
+        <xsl:variable name="json_links" select="doc('../../tmp/json-dump.xml')/tei:list" as="item()*"/>
+        <xsl:variable name="page_files" select="doc('../../tmp/html-dump.xml')/tei:list" as="item()*"/>
+        <xsl:text>PASSED: </xsl:text>
+        <xsl:value-of select="count(distinct-values(($json_links//tei:item[key('item', normalize-space(.), $page_files)])))"/>
+        <xsl:text>&#10;</xsl:text>
+        <xsl:variable name="json_errors" select="distinct-values(($json_links//tei:item[not(key('item', normalize-space(.), $page_files))]))"/>
+        <xsl:variable name="html_errors" select="distinct-values(($page_files//tei:item[not(key('item', normalize-space(.), $json_links))]))"/>
+        <xsl:if test="count($json_errors) + count($html_errors) ne 0">
+            <xsl:text>FAILED: </xsl:text>
+            <xsl:value-of select="count($json_errors) + count($html_errors)"/>
+            <xsl:text>&#10;</xsl:text>
+            <xsl:call-template name="write_error_message">
+                <xsl:with-param name="title" select="'HTML File mentioned in JSON missing:'"/>
+                <xsl:with-param name="error_items" select="$json_errors"/>
+            </xsl:call-template>
+            
+            <xsl:call-template name="write_error_message">
+                <xsl:with-param name="title" select="'Link to HTML missing in JSON:'"/>
+                <xsl:with-param name="error_items" select="$html_errors"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template name="write_error_message">
+        <xsl:param name="title"/>
+        <xsl:param name="error_items"/>
+        
+        <xsl:if test="count($error_items) gt 0">
+            <xsl:text>&#10;</xsl:text>
+            <xsl:value-of select="concat($title, ' ', count($error_items))"/>
+            <xsl:text>&#10;---------------------------------&#10;</xsl:text>
+            <xsl:value-of select="string-join($error_items, '&#10;')"/>
+            <xsl:text>&#10;&#10;</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    
+    <xsl:function name="local:convert-json-to-xml" as="item()*">
+        <xsl:param name="text" />
+        
+        <xsl:copy-of select="json-to-xml(replace($text, '^[^\{]+', ''))" />
+        
+    </xsl:function>
+    
+    <xsl:function name="local:get-item-uri" as="xs:string*">
+        <xsl:param name="string"/>
+        
+        <xsl:if test="matches($string, '^(/v1/transcription/tei/diplomatic/internal/|/v1/translation/tei/[^/]+/)')">
+            <xsl:variable name="type" as="xs:string*">
+                <xsl:choose>
+                    <xsl:when test="matches($string,'/v1/translation/tei/[^/]+/')">
+                        <xsl:value-of select="'translation'"/>
+                    </xsl:when>
+                    <xsl:otherwise/>
+                </xsl:choose>
+            </xsl:variable>
+            
+            <xsl:variable name="classmark" select="tokenize(replace($string,'^(/v1/transcription/tei/diplomatic/internal/|/v1/translation/tei/[^/]+/)', ''),'/')[1]"/>
+            <xsl:variable name="image_tokens" select="tokenize($string,'/')[position() gt index-of(tokenize($string,'/'), $classmark)]"/>
+            <xsl:sequence select="concat(string-join(($classmark,string-join(($classmark, $image_tokens, $type)[normalize-space(.)],'-'))[normalize-space(.)],'/'),'.html')"/>
+        </xsl:if>
+    </xsl:function>
+</xsl:stylesheet>

--- a/bin/test-xslt/main.xsl
+++ b/bin/test-xslt/main.xsl
@@ -8,17 +8,23 @@
         <xsl:variable name="json_links" select="doc('../../tmp/json-dump.xml')/tei:list" as="item()*"/>
         <xsl:variable name="page_files" select="doc('../../tmp/html-dump.xml')/tei:list" as="item()*"/>
         <xsl:text>PASSED: </xsl:text>
-        <xsl:value-of select="count(distinct-values(($json_links//tei:item[key('item', normalize-space(.), $page_files)])))"/>
+        <xsl:value-of select="local:commafy(count(distinct-values(($json_links//tei:item[@n][key('item', normalize-space(.), $page_files)]))))"/>
         <xsl:text>&#10;</xsl:text>
-        <xsl:variable name="json_errors" select="distinct-values(($json_links//tei:item[not(key('item', normalize-space(.), $page_files))]))"/>
+        <xsl:variable name="json_invalid_errors" select="distinct-values(($json_links//tei:item[@type='invalid']))"/>
+        <xsl:variable name="json_link_errors" select="distinct-values(($json_links//tei:item[@n][not(key('item', normalize-space(.), $page_files))]))"/>
         <xsl:variable name="html_errors" select="distinct-values(($page_files//tei:item[not(key('item', normalize-space(.), $json_links))]))"/>
-        <xsl:if test="count($json_errors) + count($html_errors) ne 0">
+        <xsl:if test="count($json_link_errors) + count($html_errors) ne 0">
             <xsl:text>FAILED: </xsl:text>
-            <xsl:value-of select="count($json_errors) + count($html_errors)"/>
+            <xsl:value-of select="local:commafy(count($json_invalid_errors) + count($json_link_errors) + count($html_errors))"/>
             <xsl:text>&#10;</xsl:text>
             <xsl:call-template name="write_error_message">
+                <xsl:with-param name="title" select="'Invalid JSON:'"/>
+                <xsl:with-param name="error_items" select="$json_invalid_errors"/>
+            </xsl:call-template>
+            
+            <xsl:call-template name="write_error_message">
                 <xsl:with-param name="title" select="'HTML File mentioned in JSON missing:'"/>
-                <xsl:with-param name="error_items" select="$json_errors"/>
+                <xsl:with-param name="error_items" select="$json_link_errors"/>
             </xsl:call-template>
             
             <xsl:call-template name="write_error_message">
@@ -34,9 +40,15 @@
         
         <xsl:if test="count($error_items) gt 0">
             <xsl:text>&#10;</xsl:text>
-            <xsl:value-of select="concat($title, ' ', count($error_items))"/>
+            <xsl:value-of select="concat($title, ' ', local:commafy(count($error_items)))"/>
             <xsl:text>&#10;---------------------------------&#10;</xsl:text>
-            <xsl:value-of select="string-join($error_items, '&#10;')"/>
+            <xsl:for-each select="$error_items">
+                <xsl:sort select="."/>
+                <xsl:value-of select="."/>
+                <xsl:if test="position() ne last()">
+                    <xsl:text>&#10;</xsl:text>
+                </xsl:if>
+            </xsl:for-each>
             <xsl:text>&#10;&#10;</xsl:text>
         </xsl:if>
     </xsl:template>
@@ -66,5 +78,11 @@
             <xsl:variable name="image_tokens" select="tokenize($string,'/')[position() gt index-of(tokenize($string,'/'), $classmark)]"/>
             <xsl:sequence select="concat(string-join(($classmark,string-join(($classmark, $image_tokens, $type)[normalize-space(.)],'-'))[normalize-space(.)],'/'),'.html')"/>
         </xsl:if>
+    </xsl:function>
+    
+    <xsl:function name="local:commafy" as="xs:string*">
+        <xsl:param name="number"/>
+        
+        <xsl:value-of select="format-number($number,'###,###,###')"/>
     </xsl:function>
 </xsl:stylesheet>

--- a/bin/test.xml
+++ b/bin/test.xml
@@ -38,7 +38,7 @@
                 </factory>
             </xslt>
             
-            <delete dir="${tmp.dir}" />
+            <delete dir="${tmp.dir}" failonerror="no" />
         </target>
 
     </project>

--- a/bin/test.xml
+++ b/bin/test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <project name="test" default="full">
+        <taskdef resource="net/sf/antcontrib/antlib.xml"/>
+        
+        <import file="build.xml" as="nesting" />
+        
+        <target name="full" depends="transcripts,json,tests-only"/>
+        
+        <target name="tests-only">
+            <property name="tmp.dir" value="../tmp"/><!-- directory containing dumps of the json information and existing html files-->
+            
+            <delete dir="${tmp.dir}" />
+            <delete file="../test.log"/>
+            
+            <mkdir dir="${tmp.dir}"/>
+            
+            <xslt out="${tmp.dir}/json-dump.xml" in="test-xslt/dump-json.xsl" style="test-xslt/dump-json.xsl" force="true" useimplicitfileset="false" classpath="saxon/saxon-he-10.2.jar" reloadstylesheet="true">
+                <fileset refid="original_xml"/>
+                <factory name="net.sf.saxon.TransformerFactoryImpl">
+                    <attribute name="http://saxon.sf.net/feature/xinclude-aware"
+                        value="true"/>
+                </factory>
+            </xslt>
+            
+            <xslt out="${tmp.dir}/html-dump.xml" in="test-xslt/dump-html.xsl" style="test-xslt/dump-html.xsl" force="true" useimplicitfileset="false" classpath="saxon/saxon-he-10.2.jar" reloadstylesheet="true">
+                <fileset refid="original_xml"/>
+                <factory name="net.sf.saxon.TransformerFactoryImpl">
+                    <attribute name="http://saxon.sf.net/feature/xinclude-aware"
+                        value="true"/>
+                </factory>
+            </xslt>
+            
+            <xslt out="../test.log" in="test-xslt/main.xsl" style="test-xslt/main.xsl" force="true" useimplicitfileset="false" classpath="saxon/saxon-he-10.2.jar" reloadstylesheet="true">
+                <fileset refid="original_xml"/>
+                <factory name="net.sf.saxon.TransformerFactoryImpl">
+                    <attribute name="http://saxon.sf.net/feature/xinclude-aware"
+                        value="true"/>
+                </factory>
+            </xslt>
+            
+            <delete dir="${tmp.dir}" />
+        </target>
+
+    </project>


### PR DESCRIPTION
The changes to build.xml were to support the test suite. The changes include adding:
- the capacity to generate json files locally
- the ability to build both all resources locally (pages and json) or just html or json.

The test suite now checks that
- all transcript links in the json point to existing html page files
- all html page files are referred to from the json

The results of the tests are written to ./test.log.

We still need to add the ability check the json files for wellformedness. At present, the test will crash if it encounters a malformed json file.
