### PR TITLE
Restore missing lb

### DIFF
--- a/xslt/transcription/p5-transcription-body.xsl
+++ b/xslt/transcription/p5-transcription-body.xsl
@@ -587,7 +587,7 @@
     <xsl:next-match/>
   </xsl:template>
   
-  <xsl:template match="tei:lb[not(cudl:is_first_significant_child(.))]" priority="1" mode="#all">
+  <xsl:template match="tei:lb[not(cudl:is_first_significant_child(.))]|tei:lb[@facs]" priority="1" mode="#all">
     <br>
       <xsl:attribute name="xml:id" select="replace(normalize-space(@facs),'^#', '')"/>
       <xsl:apply-templates select="@facs" mode="data-points"/>
@@ -608,7 +608,7 @@
        since a terminal br at the end of a block doesn't cause an extra line break
        on the screen
   -->
-  <xsl:template match="tei:lb[cudl:is_first_significant_child(.)]" mode="#all"/>
+  <xsl:template match="tei:lb[not(@facs)][cudl:is_first_significant_child(.)]" mode="#all"/>
   
   <!-- list and item are just being output in generic containers. 
        switch to semantic html elements?


### PR DESCRIPTION
The initial lb was missing because the display code filtered them out to avoid outputting a superfluous additional line break at the start of every paragraph. The logic of that filtering need to be revisited the next time this code is refactored since it might result in some other line breaks being omitted from the output. For the time being, however, I have modified it so that any lb with a facs attribute is processed.